### PR TITLE
Set qualname.

### DIFF
--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -309,7 +309,11 @@ PyFunction_BindCoAnnotations(PyObject *owner, PyObject **co_annotations, PyObjec
         return -1;
     }
 
-    PyFunctionObject *fn = (PyFunctionObject *)PyFunction_New(co, globals);
+    PyObject *qualname = PyUnicode_FromFormat("%U.%s", ((PyFunctionObject*)owner)->func_qualname, "__co_annotations__");
+    if (qualname == NULL) {
+        PyErr_Clear();
+    }
+    PyFunctionObject *fn = (PyFunctionObject *)PyFunction_NewWithQualName(co, globals, qualname);
     if (!fn) {
         PyErr_Format(PyExc_ValueError,
                      "%R __co_annotations__ couldn't bind function object",

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -765,8 +765,6 @@ compiler_exit_scope(struct compiler *c)
 }
 
 
-static PyObject *dot_co_annotations = NULL;
-
 /*
  * Returns >0 if we succeeded and are currently in the annotation scope.
  * Returns  0 if there was an error.
@@ -788,20 +786,8 @@ compiler_enter_co_annotations_scope(struct compiler *c)
     int co_annotations = c->c_future->ff_features & CO_FUTURE_CO_ANNOTATIONS;
 
     if (co_annotations) {
-         if (!c->u->u_asi.basename) {
-            return -1;
-        }
-
-       if (dot_co_annotations == NULL) {
-            dot_co_annotations = PyUnicode_InternFromString(".__co_annotations__");
-            if (!dot_co_annotations)
-                return 0;
-        }
-
-        PyObject *name_dot_co_annotations = PyUnicode_Concat(c->u->u_asi.basename, dot_co_annotations);
-
         if (!compiler_enter_scope(c,
-            name_dot_co_annotations,
+            __co_annotations__,
             COMPILER_SCOPE_ANNOTATION,
             c->u->u_asi.ast,
             c->u->u_asi.line))


### PR DESCRIPTION
```
>>> from __future__ import co_annotations
>>> def foo(a:int, b:str) -> None: pass
...
>>> f = foo.__co_annotations__
>>> f
<function foo.__co_annotations__ at 0x7f87a834c940>
>>> f.__name__
'__co_annotations__'
>>> f.__qualname__
'foo.__co_annotations__'
```