### PR TITLE
Account for co_annotations in MAKE_FUNCTION stack_effect().

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1239,7 +1239,7 @@ stack_effect(int opcode, int oparg, int jump)
             return -1 - ((oparg & 0x01) != 0);
         case MAKE_FUNCTION:
             return -1 - ((oparg & 0x01) != 0) - ((oparg & 0x02) != 0) -
-                ((oparg & 0x04) != 0) - ((oparg & 0x08) != 0);
+                ((oparg & 0x04) != 0) - ((oparg & 0x08) != 0) - ((oparg & 0x10) != 0);
         case BUILD_SLICE:
             if (oparg == 3)
                 return -2;
@@ -6724,4 +6724,3 @@ PyCode_Optimize(PyObject *code, PyObject* Py_UNUSED(consts),
     Py_INCREF(code);
     return code;
 }
-


### PR DESCRIPTION
Just happened to notice this while poking around; given #12 I haven't been able to really verify this fix yet, but I'm pretty sure it's correct. If a `MAKE_FUNCTION` oparg has the `co_annotations` flag set, that `MAKE_FUNCTION` opcode will consume one more element off the stack than it otherwise would, and if this isn't reflected in `stack_effect()`, it will result in an overestimation of the needed stack size.