### PR TITLE
fix assert in MAKE_FUNCTION

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3852,7 +3852,7 @@ main_loop:
                 func->func_locals = f->f_locals;
             }
             if (oparg & 0x10) {
-                assert(TOP()->ob_type == &PyCode_Type);
+                assert(TOP()->ob_type == &PyCode_Type || TOP()->ob_type == &PyTuple_Type);
                 func->func_co_annotations = POP();
             }
             if (oparg & 0x04) {


### PR DESCRIPTION
https://github.com/larryhastings/co_annotations/commit/b42ce636f2bfe9a24faa01b63adecabaae5eb6a1 didn't update an assertion in `MAKE_FUNCTION` handler in ceval, which causes a crash in debug builds. Update the assertion to accept either of the now two possible types for `__co_annotations__`, a code object or a tuple.

Fixes #12 