### PR TITLE
Fix setting __annotations__ on a function

### DIFF
--- a/Lib/test/future_co_annotations.py
+++ b/Lib/test/future_co_annotations.py
@@ -34,3 +34,8 @@ def closure_and_classvars():
         x = method1.__annotations__
         y = method2.__annotations__
     return C
+
+def foo() -> int:
+    pass
+
+foo.__annotations__ = {"return": int}

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -615,15 +615,6 @@ func_get_annotations(PyFunctionObject *op, void *Py_UNUSED(ignored))
 static int
 func_set_annotations(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored))
 {
-    assert(op->func_co_annotations);
-    if (!((op->func_co_annotations == Py_None)
-        || PyCallable_Check(op->func_co_annotations)
-        || PyTuple_Check(op->func_co_annotations))) {
-        PyErr_SetString(
-            PyExc_RuntimeError,
-            "__co_annotations__ is somehow neither None nor a callable nor a tuple");
-        return -1;
-    }
     if (value == Py_None)
         value = NULL;
     /* Legal to del f.func_annotations.


### PR DESCRIPTION
Setting `__annotations__` on a function was broken in the common case where `func_co_annotations` is a simple code object, because there's an assertion in `func_set_annotations` that expects it to always be a function or tuple or None.

A typical realistic case for setting `__annotations__` on a function is the use of `@functools.wraps`, which copies over
various attributes (including `__annotations__`) from the wrapped function to the wrapper.

It's not clear why `func_set_annotations` in particular should care what `func_co_annotations` is set to, so I propose here to just remove this assertion/error. We could also add a clause checking for code object and allowing that.